### PR TITLE
parse-sass.sh scripts are modified with sassc running options.

### DIFF
--- a/admin-gtk3-dark-osx/gtk-3.0/parse-sass.sh
+++ b/admin-gtk3-dark-osx/gtk-3.0/parse-sass.sh
@@ -5,7 +5,8 @@ if ! command -v sassc &>/dev/null; then
    exit 1
 fi
 
-SASSC_OPT=('-t' 'compressed')
+#SASSC_OPT=('-t' 'compressed')
+SASSC_OPT=('-t' 'compact')
 
 echo Generating the css...
 

--- a/admin-gtk3-dark-slimmer-osx/gtk-3.0/parse-sass.sh
+++ b/admin-gtk3-dark-slimmer-osx/gtk-3.0/parse-sass.sh
@@ -5,7 +5,8 @@ if ! command -v sassc &>/dev/null; then
    exit 1
 fi
 
-SASSC_OPT=('-t' 'compressed')
+#SASSC_OPT=('-t' 'compressed')
+SASSC_OPT=('-t' 'compact')
 
 echo Generating the css...
 

--- a/admin-gtk3-dark-slimmer-vertex/gtk-3.0/parse-sass.sh
+++ b/admin-gtk3-dark-slimmer-vertex/gtk-3.0/parse-sass.sh
@@ -5,7 +5,8 @@ if ! command -v sassc &>/dev/null; then
    exit 1
 fi
 
-SASSC_OPT=('-t' 'compressed')
+#SASSC_OPT=('-t' 'compressed')
+SASSC_OPT=('-t' 'compact')
 
 echo Generating the css...
 

--- a/admin-gtk3-dark-vertex/gtk-3.0/parse-sass.sh
+++ b/admin-gtk3-dark-vertex/gtk-3.0/parse-sass.sh
@@ -5,7 +5,8 @@ if ! command -v sassc &>/dev/null; then
    exit 1
 fi
 
-SASSC_OPT=('-t' 'compressed')
+#SASSC_OPT=('-t' 'compressed')
+SASSC_OPT=('-t' 'compact')
 
 echo Generating the css...
 

--- a/admin-gtk3-dark/gtk-3.0/parse-sass.sh
+++ b/admin-gtk3-dark/gtk-3.0/parse-sass.sh
@@ -5,7 +5,8 @@ if ! command -v sassc &>/dev/null; then
    exit 1
 fi
 
-SASSC_OPT=('-t' 'compressed')
+#SASSC_OPT=('-t' 'compressed')
+SASSC_OPT=('-t' 'compact')
 
 echo Generating the css...
 

--- a/admin-gtk3-light-osx/gtk-3.0/parse-sass.sh
+++ b/admin-gtk3-light-osx/gtk-3.0/parse-sass.sh
@@ -5,7 +5,8 @@ if ! command -v sassc &>/dev/null; then
    exit 1
 fi
 
-SASSC_OPT=('-t' 'compressed')
+#SASSC_OPT=('-t' 'compressed')
+SASSC_OPT=('-t' 'compact')
 
 echo Generating the css...
 

--- a/admin-gtk3-light-slimmer-osx/gtk-3.0/parse-sass.sh
+++ b/admin-gtk3-light-slimmer-osx/gtk-3.0/parse-sass.sh
@@ -5,7 +5,8 @@ if ! command -v sassc &>/dev/null; then
    exit 1
 fi
 
-SASSC_OPT=('-t' 'compressed')
+#SASSC_OPT=('-t' 'compressed')
+SASSC_OPT=('-t' 'compact')
 
 echo Generating the css...
 

--- a/admin-gtk3-light-slimmer-vertex/gtk-3.0/parse-sass.sh
+++ b/admin-gtk3-light-slimmer-vertex/gtk-3.0/parse-sass.sh
@@ -5,7 +5,8 @@ if ! command -v sassc &>/dev/null; then
    exit 1
 fi
 
-SASSC_OPT=('-t' 'compressed')
+#SASSC_OPT=('-t' 'compressed')
+SASSC_OPT=('-t' 'compact')
 
 echo Generating the css...
 

--- a/admin-gtk3-light-vertex/gtk-3.0/parse-sass.sh
+++ b/admin-gtk3-light-vertex/gtk-3.0/parse-sass.sh
@@ -5,7 +5,8 @@ if ! command -v sassc &>/dev/null; then
    exit 1
 fi
 
-SASSC_OPT=('-t' 'compressed')
+#SASSC_OPT=('-t' 'compressed')
+SASSC_OPT=('-t' 'compact')
 
 echo Generating the css...
 

--- a/admin-gtk3-light/gnome-shell/parse-sass.sh
+++ b/admin-gtk3-light/gnome-shell/parse-sass.sh
@@ -5,7 +5,8 @@ if ! command -v sassc &>/dev/null; then
    exit 1
 fi
 
-SASSC_OPT=('-t' 'compressed')
+#SASSC_OPT=('-t' 'compressed')
+SASSC_OPT=('-t' 'compact')
 
 echo Generating the css...
 

--- a/admin-gtk3-light/gtk-3.0/parse-sass.sh
+++ b/admin-gtk3-light/gtk-3.0/parse-sass.sh
@@ -5,7 +5,8 @@ if ! command -v sassc &>/dev/null; then
    exit 1
 fi
 
-SASSC_OPT=('-t' 'compressed')
+#SASSC_OPT=('-t' 'compressed')
+SASSC_OPT=('-t' 'compact')
 
 echo Generating the css...
 


### PR DESCRIPTION
Now scripts call sassc with “-t compact” instead of “-t compressed”.

Previously, css files were generated without semicolon and this raised parsing error.

Gtk-WARNING **: 13:48:16.652: Theme parsing error: gtk.css:1:120542: unknown syntax for transform
[…]

Now gtk.css generated with spaces and semicolon, e.g.:
@keyframes spin { to { -gtk-icon-transform: rotate(1turn); } }

Instead of this:
@keyframes spin{to{-gtk-icon-transform:rotate(1turn)}}